### PR TITLE
fix: update cache logic, fix initial load data from api

### DIFF
--- a/lib/features/character/data/datasources/local_character_datasource.dart
+++ b/lib/features/character/data/datasources/local_character_datasource.dart
@@ -4,7 +4,7 @@ import 'package:hive_ce_flutter/hive_flutter.dart';
 
 abstract class LocalCharacterDataSource {
   Future<void> cachePage(PageModel pageToCache);
-  Future<PageModel> getCachedPages(int pageNumber);
+  Future<PageModel> getCachedPage(int pageNumber);
   Future<void> replaceCachedPage(PageModel page);
   Future<bool> isCacheNotEmpty();
 }
@@ -21,7 +21,7 @@ class LocalCharacterDataSourceImpl implements LocalCharacterDataSource {
   }
 
   @override
-  Future<PageModel> getCachedPages(int pageNumber) async {
+  Future<PageModel> getCachedPage(int pageNumber) async {
     final cachePage = pageBox.get(pageNumber);
     if (cachePage != null) {
       return Future.value(cachePage);

--- a/lib/features/character/data/datasources/remote_character_datasource.dart
+++ b/lib/features/character/data/datasources/remote_character_datasource.dart
@@ -6,7 +6,7 @@ import 'package:http/http.dart' as http;
 import 'dart:convert';
 
 abstract class RemoteCharacterDataSource {
-  Future<PageModel> getPage(int page);
+  Future<PageModel> getPage(int pageNumber);
 }
 
 class RemoteCharacterDataSourceImpl implements RemoteCharacterDataSource {
@@ -15,12 +15,16 @@ class RemoteCharacterDataSourceImpl implements RemoteCharacterDataSource {
   RemoteCharacterDataSourceImpl({required this.client});
 
   @override
-  Future<PageModel> getPage(int page) async {
-    final response = await client.get(Uri.parse(Urls.getCharactersPage(page)));
+  Future<PageModel> getPage(int pageNumber) async {
+    final response = await client.get(
+      Uri.parse(Urls.getCharactersPage(pageNumber)),
+    );
     if (response.statusCode == 200) {
       final json = jsonDecode(response.body);
       final etag = response.headers['etag'];
-      return PageModel.fromJson(json).copyWith(pageNumber: page, etag: etag);
+      return PageModel.fromJson(
+        json,
+      ).copyWith(pageNumber: pageNumber, etag: etag);
     } else {
       throw ServerException();
     }

--- a/lib/features/character/data/models/page_model.dart
+++ b/lib/features/character/data/models/page_model.dart
@@ -9,6 +9,7 @@ class PageModel extends HiveObject {
   final String? next;
   final String? prev;
   final List<CharacterModel> characters;
+  final String? etag;
 
   PageModel({
     required this.pageNumber,
@@ -17,6 +18,7 @@ class PageModel extends HiveObject {
     this.next,
     this.prev,
     required this.characters,
+    required this.etag,
   });
 
   PageEntity toEntity() {
@@ -38,6 +40,7 @@ class PageModel extends HiveObject {
       prev: entity.prev,
       characters:
           entity.characters.map((c) => CharacterModel.fromEntity(c)).toList(),
+      etag: '',
     );
   }
 
@@ -52,6 +55,7 @@ class PageModel extends HiveObject {
           (json['results'] as List)
               .map((e) => CharacterModel.fromJson(e as Map<String, dynamic>))
               .toList(),
+      etag: '',
     );
   }
 
@@ -70,6 +74,7 @@ class PageModel extends HiveObject {
       next: next,
       prev: prev,
       characters: characters,
+      etag: etag ?? this.etag,
     );
   }
 }

--- a/lib/features/character/domain/repositories/character_repository.dart
+++ b/lib/features/character/domain/repositories/character_repository.dart
@@ -4,5 +4,5 @@ import 'package:dartz/dartz.dart';
 import '../../../../core/error/failures.dart';
 
 abstract class CharacterRepository {
-  Future<Either<Failure, PageEntity>> getPage(int page);
+  Future<Either<Failure, PageEntity>> getPage(int pageNumber);
 }

--- a/lib/hive/hive_adapters.g.dart
+++ b/lib/hive/hive_adapters.g.dart
@@ -23,13 +23,14 @@ class PageModelAdapter extends TypeAdapter<PageModel> {
       next: fields[2] as String?,
       prev: fields[3] as String?,
       characters: (fields[4] as List).cast<CharacterModel>(),
+      etag: fields[8] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, PageModel obj) {
     writer
-      ..writeByte(6)
+      ..writeByte(7)
       ..writeByte(0)
       ..write(obj.count)
       ..writeByte(1)
@@ -41,7 +42,9 @@ class PageModelAdapter extends TypeAdapter<PageModel> {
       ..writeByte(4)
       ..write(obj.characters)
       ..writeByte(5)
-      ..write(obj.pageNumber);
+      ..write(obj.pageNumber)
+      ..writeByte(8)
+      ..write(obj.etag);
   }
 
   @override

--- a/lib/hive/hive_adapters.g.yaml
+++ b/lib/hive/hive_adapters.g.yaml
@@ -5,7 +5,7 @@ nextTypeId: 2
 types:
   PageModel:
     typeId: 0
-    nextIndex: 8
+    nextIndex: 9
     fields:
       count:
         index: 0
@@ -19,6 +19,8 @@ types:
         index: 4
       pageNumber:
         index: 5
+      etag:
+        index: 8
   CharacterModel:
     typeId: 1
     nextIndex: 6


### PR DESCRIPTION
Fix: Data Loading Issue
This PR fixes a bug where users would see an error page if the local storage was empty when opening the app.

Changes & Improvements:

- Previously, data was only loaded from local storage on app startup. If the storage was empty, an error page was shown.

- Now, data is fetched from a remote source if local storage is empty, ensuring the app always has content to display.

- On subsequent app launches, data is first loaded from local storage.

- An ETag-based validation has been implemented to check data freshness. If the stored data is outdated, it is updated from the remote source.

Outcome:

- Users no longer encounter an error when local storage is empty.

- The app loads faster by prioritizing cached data while ensuring it stays up to date.