### PR TITLE
feat: add sorting for favorite characters with dropdown selection 

### DIFF
--- a/lib/core/util/character/fav_characters_sort_type.dart
+++ b/lib/core/util/character/fav_characters_sort_type.dart
@@ -1,0 +1,1 @@
+enum SortType { defaultOrder, byName, bySpecies, byStatus, byType }

--- a/lib/features/fav_characters/presentation/cubit/sort_characters_cubit.dart
+++ b/lib/features/fav_characters/presentation/cubit/sort_characters_cubit.dart
@@ -1,0 +1,44 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/util/character/fav_characters_sort_type.dart';
+import '../../domain/entities/character_entity.dart';
+
+part 'sort_characters_state.dart';
+
+class FavCharactersSortingCubit extends Cubit<FavCharactersSortingState> {
+  FavCharactersSortingCubit() : super(FavCharactersSortingInitial());
+
+  void loadCharacters(List<CharacterEntity> characters) {
+    emit(
+      FavCharactersSortingLoaded(
+        sortedList: characters,
+        sortType: SortType.defaultOrder,
+      ),
+    );
+  }
+
+  void sortCharacters(List<CharacterEntity> characters, SortType sortType) {
+    List<CharacterEntity> sortedList = List.from(characters);
+
+    switch (sortType) {
+      case SortType.byName:
+        sortedList.sort((a, b) => a.name.compareTo(b.name));
+        break;
+      case SortType.bySpecies:
+        sortedList.sort((a, b) => a.species.compareTo(b.species));
+        break;
+      case SortType.byStatus:
+        sortedList.sort((a, b) => a.status.compareTo(b.status));
+        break;
+      case SortType.byType:
+        sortedList.sort((a, b) => a.type.compareTo(b.type));
+        break;
+      case SortType.defaultOrder:
+        break;
+    }
+    emit(
+      FavCharactersSortingLoaded(sortedList: sortedList, sortType: sortType),
+    );
+  }
+}

--- a/lib/features/fav_characters/presentation/cubit/sort_characters_state.dart
+++ b/lib/features/fav_characters/presentation/cubit/sort_characters_state.dart
@@ -1,0 +1,23 @@
+part of 'sort_characters_cubit.dart';
+
+sealed class FavCharactersSortingState extends Equatable {
+  const FavCharactersSortingState();
+
+  @override
+  List<Object> get props => [];
+}
+
+final class FavCharactersSortingInitial extends FavCharactersSortingState {}
+
+final class FavCharactersSortingLoaded extends FavCharactersSortingState {
+  final List<CharacterEntity> sortedList;
+  final SortType sortType;
+
+  const FavCharactersSortingLoaded({
+    required this.sortedList,
+    required this.sortType,
+  });
+
+  @override
+  List<Object> get props => [sortedList, sortType];
+}

--- a/lib/features/fav_characters/presentation/pages/fav_characters_page.dart
+++ b/lib/features/fav_characters/presentation/pages/fav_characters_page.dart
@@ -1,10 +1,12 @@
 import 'package:auto_route/annotations.dart';
 import 'package:characters_list_app/features/fav_characters/presentation/widgets/fav_character_display.dart';
+import 'package:characters_list_app/features/fav_characters/presentation/widgets/sort_dropdown_menu.dart';
 import 'package:characters_list_app/injection_container/injection_container_export.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../characters_page/presentation/widgets/characters_failure_display.dart';
+import '../cubit/sort_characters_cubit.dart';
 
 @RoutePage()
 class FavCharactersPage extends StatelessWidget {
@@ -13,24 +15,32 @@ class FavCharactersPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     context.read<FavCharactersBloc>().add(FavCharactersLoad());
+
     return Scaffold(
+      appBar: AppBar(actions: [SortDropdownMenu()]),
       body: SafeArea(
         child: BlocBuilder<FavCharactersBloc, FavCharactersState>(
           builder: (context, state) {
             if (state is FavCharactersInitial) {
-              return CharactersLoadingDisplay();
+              return const CharactersLoadingDisplay();
             }
             if (state is FavCharactersLoaded) {
-              return state.favCharactersList.isEmpty
-                  ? Center(child: Text('We didn`t find any characters'))
-                  : FavCharacterDisplay(
-                    favCharactersList: state.favCharactersList,
-                  );
+              if (state.favCharactersList.isEmpty) {
+                return const Center(
+                  child: Text('We didn’t find any characters'),
+                );
+              }
+
+              context.read<FavCharactersSortingCubit>().loadCharacters(
+                state.favCharactersList,
+              );
+
+              return const FavCharacterDisplay();
             }
             if (state is FavCharactersFailure) {
               return Center(child: Text(state.message));
             }
-            return Center(child: CircularProgressIndicator());
+            return const Center(child: CircularProgressIndicator());
           },
         ),
       ),

--- a/lib/features/fav_characters/presentation/widgets/fav_character_display.dart
+++ b/lib/features/fav_characters/presentation/widgets/fav_character_display.dart
@@ -1,25 +1,33 @@
-import 'package:characters_list_app/features/fav_characters/domain/entities/character_entity.dart';
+import 'package:characters_list_app/features/fav_characters/presentation/cubit/sort_characters_cubit.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/widgets/character_card.dart';
 
 class FavCharacterDisplay extends StatelessWidget {
-  final List<CharacterEntity> favCharactersList;
-  const FavCharacterDisplay({super.key, required this.favCharactersList});
+  const FavCharacterDisplay({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(5.0),
-      child: GridView.builder(
-        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: 2,
-          mainAxisSpacing: 5,
-          crossAxisSpacing: 5,
-        ),
-        itemCount: favCharactersList.length,
-        itemBuilder: (context, index) {
-          return CharacterCard(character: favCharactersList[index]);
+      child: BlocBuilder<FavCharactersSortingCubit, FavCharactersSortingState>(
+        builder: (context, state) {
+          if (state is FavCharactersSortingLoaded) {
+            return GridView.builder(
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+                mainAxisSpacing: 5,
+                crossAxisSpacing: 5,
+              ),
+              itemCount: state.sortedList.length,
+              itemBuilder: (context, index) {
+                return CharacterCard(character: state.sortedList[index]);
+              },
+            );
+          }
+          return const Center(child: CircularProgressIndicator());
         },
       ),
     );

--- a/lib/features/fav_characters/presentation/widgets/sort_dropdown_menu.dart
+++ b/lib/features/fav_characters/presentation/widgets/sort_dropdown_menu.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/util/character/fav_characters_sort_type.dart';
+import '../bloc/fav_characters_bloc.dart';
+import '../cubit/sort_characters_cubit.dart';
+
+class SortDropdownMenu extends StatelessWidget {
+  const SortDropdownMenu({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<FavCharactersSortingCubit, FavCharactersSortingState>(
+      builder: (context, sortState) {
+        SortType currentSortType = SortType.defaultOrder;
+
+        if (sortState is FavCharactersSortingLoaded) {
+          currentSortType = sortState.sortType;
+        }
+
+        return DropdownButton<SortType>(
+          icon: const Padding(
+            padding: EdgeInsets.all(8.0),
+            child: Icon(Icons.sort),
+          ),
+          items:
+              SortType.values.map((SortType value) {
+                return DropdownMenuItem<SortType>(
+                  value: value,
+                  child: Text(
+                    value.toString().split('.').last,
+                    style: TextStyle(
+                      fontWeight:
+                          value == currentSortType
+                              ? FontWeight.bold
+                              : FontWeight.normal,
+                    ),
+                  ),
+                );
+              }).toList(),
+          onChanged: (SortType? newValue) {
+            if (newValue != null) {
+              context.read<FavCharactersSortingCubit>().sortCharacters(
+                context.read<FavCharactersBloc>().state.favCharactersList,
+                newValue,
+              );
+            }
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/injection_container/injection_container.dart
+++ b/lib/injection_container/injection_container.dart
@@ -1,5 +1,6 @@
 import 'package:http/http.dart' as http;
 
+import '../features/fav_characters/presentation/cubit/sort_characters_cubit.dart';
 import 'injection_container_export.dart';
 
 final sl = GetIt.instance;
@@ -9,6 +10,9 @@ Future<void> init() async {
 
   // Bloc
   sl.registerFactory(() => CharactersPageBloc(getCharactersPage: sl()));
+
+  //Cubit
+  sl.registerFactory(() => FavCharactersSortingCubit());
 
   // Use cases
   sl.registerLazySingleton(() => GetCharactersPage(sl()));

--- a/lib/rick_and_morty_characters_app.dart
+++ b/lib/rick_and_morty_characters_app.dart
@@ -1,6 +1,7 @@
 import 'package:characters_list_app/config/router/router.dart';
 import 'package:characters_list_app/features/characters_page/presentation/bloc/character_bloc.dart';
 import 'package:characters_list_app/features/fav_characters/presentation/bloc/fav_characters_bloc.dart';
+import 'package:characters_list_app/features/fav_characters/presentation/cubit/sort_characters_cubit.dart';
 import 'package:talker_flutter/talker_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -15,6 +16,7 @@ class RickAndMortyCharactersApp extends StatelessWidget {
       providers: [
         BlocProvider(create: (_) => di.sl<CharactersPageBloc>()),
         BlocProvider(create: (_) => di.sl<FavCharactersBloc>()),
+        BlocProvider(create: (_) => di.sl<FavCharactersSortingCubit>()),
       ],
       child: MaterialApp.router(
         routerConfig: di.sl<AppRouter>().config(


### PR DESCRIPTION
### What’s Changed?

Added sorting logic to the FavCharactersSortingCubit.
- Stores and manages the current sorting type.
- Sorts the list of favorite characters based on the selected option.

Added a sorting dropdown menu:
- Allows users to select the sorting type.
- The currently selected sorting type is highlighted inside the dropdown.

Sorting logic:
- Sorting updates happen automatically without requiring a FavCharactersBloc rebuild.

### Why?

- Enables users to sort favorite characters easily.
- Improves usability by clearly indicating the selected sorting option.
- Ensures clean separation between UI and business logic.