### PR TITLE
feat(ui): add spin animation to favorite icon toggle

### DIFF
--- a/lib/core/widgets/character_card.dart
+++ b/lib/core/widgets/character_card.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:characters_list_app/features/fav_characters/domain/entities/character_entity.dart';
@@ -65,14 +67,17 @@ class CharacterCard extends StatelessWidget {
                     color: Colors.white,
                   ),
                   child: IconButton(
-                    padding: EdgeInsets.all(0),
+                    padding: EdgeInsets.zero,
                     isSelected: isFavorite,
-                    onPressed:
-                        () => context.read<FavCharactersBloc>().add(
-                          FavCharacterToggle(character),
-                        ),
-                    icon: Icon(Icons.star_border),
-                    selectedIcon: Icon(Icons.star),
+                    onPressed: () {
+                      context.read<FavCharactersBloc>().add(
+                        FavCharacterToggle(character),
+                      );
+                    },
+                    icon: animatedStarIcon(
+                      isFavorite: isFavorite,
+                      key: ValueKey(isFavorite),
+                    ),
                   ),
                 ),
               ),
@@ -82,4 +87,34 @@ class CharacterCard extends StatelessWidget {
       ),
     );
   }
+}
+
+Widget animatedStarIcon({required bool isFavorite, required Key key}) {
+  return AnimatedSwitcher(
+    duration: const Duration(milliseconds: 300),
+    transitionBuilder: (Widget child, Animation<double> animation) {
+      final spinAnimation = Tween(begin: pi, end: 0.0).animate(animation);
+
+      return AnimatedBuilder(
+        animation: spinAnimation,
+        child: child,
+        builder: (context, child) {
+          final isUnder = child!.key != ValueKey(isFavorite);
+          final value =
+              isUnder ? min(spinAnimation.value, pi / 2) : spinAnimation.value;
+
+          return Transform(
+            transform: Matrix4.rotationY(value),
+            alignment: Alignment.center,
+            child: child,
+          );
+        },
+      );
+    },
+    child: Icon(
+      isFavorite ? Icons.star : Icons.star_border,
+      key: ValueKey(isFavorite),
+      color: isFavorite ? Colors.deepPurple : Colors.grey,
+    ),
+  );
 }


### PR DESCRIPTION
Replaced static favorite icon with a flip animation using AnimatedSwitcher and Transform.

This enhancement improves the visual feedback when toggling a character as favorite. The animation rotates the icon along the Y-axis, creating a smooth and intuitive transition between filled and outlined star icons.

Why this is the right choice:
- Enhances user interaction without changing logic.
- Uses ValueKey-based AnimatedSwitcher for clean widget replacement.